### PR TITLE
Adds sourcemapping-files to aid debugging

### DIFF
--- a/tasks/webpack.dev.js
+++ b/tasks/webpack.dev.js
@@ -9,6 +9,7 @@ module.exports = merge(common, {
     libraryExport: 'default',
     library: 'Origo'
   },
+  devtool: 'source-map',
   devServer: {
     contentBase: './',
     port: 9966,


### PR DESCRIPTION
To test run the code base in debug mode 

```npm run start```

When debugging in the browser the original source files should be available to set breakpoints on.