### PR TITLE
feat: add symbol to material-icons

### DIFF
--- a/css/svg/material-icons.svg
+++ b/css/svg/material-icons.svg
@@ -62,4 +62,6 @@
   <symbol viewBox="0 0 24 24" id="ic_download_24px"><path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z" /></symbol>
   <symbol viewBox="0 0 24 24" id="ic_upload_file_24px"><path d="M11 19h2v-4.175l1.6 1.6L16 15l-4-4-4 4 1.425 1.4L11 14.825Zm-5 3q-.825 0-1.412-.587Q4 20.825 4 20V4q0-.825.588-1.413Q5.175 2 6 2h8l6 6v12q0 .825-.587 1.413Q18.825 22 18 22Zm7-13V4H6v16h12V9ZM6 4v5-5 16V4Z"/></symbol>
   <symbol viewBox="0 0 24 24" id="ic_textsms_24px"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM9 11H7V9h2v2zm4 0h-2V9h2v2zm4 0h-2V9h2v2z"/></symbol>
+  <!-- material symbols -->
+  <symbol viewBox="0 -960 960 960" id="ic_add_notes_24px"><path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v268q-19-9-39-15.5t-41-9.5v-243H200v560h242q3 22 9.5 42t15.5 38H200Zm0-120v40-560 243-3 280Zm80-40h163q3-21 9.5-41t14.5-39H280v80Zm0-160h244q32-30 71.5-50t84.5-27v-3H280v80Zm0-160h400v-80H280v80ZM720-40q-83 0-141.5-58.5T520-240q0-83 58.5-141.5T720-440q83 0 141.5 58.5T920-240q0 83-58.5 141.5T720-40Zm-20-80h40v-100h100v-40H740v-100h-40v100H600v40h100v100Z"/></symbol>
 </svg>


### PR DESCRIPTION
Adds a symbol used with the extended functionality in the layermanager-csw plugin, the commit for the extended functionality is linked in the description. (https://github.com/Eskilstuna-kommun/layermanager-csw/commit/dc85f21164b3e32f92a8061f6d69cb7bf80b4ed6)